### PR TITLE
Ignore vertical swipe on the slider

### DIFF
--- a/TvOSSlider/TvOSSlider.swift
+++ b/TvOSSlider/TvOSSlider.swift
@@ -439,10 +439,22 @@ public final class TvOSSlider: UIControl {
         sendActions(for: .valueChanged)
     }
     
+    private func isVerticalGesture(_ recognizer: UIPanGestureRecognizer) -> Bool {
+        let translation = recognizer.translation(in: self)
+        if abs(translation.y) > abs(translation.x) {
+            return true
+        }
+        return false
+    }
+    
     // MARK: - Actions
     
     @objc
     private func panGestureWasTriggered(panGestureRecognizer: UIPanGestureRecognizer) {
+        if self.isVerticalGesture(panGestureRecognizer) {
+            return
+        }
+        
         let translation = Float(panGestureRecognizer.translation(in: self).x)
         let velocity = Float(panGestureRecognizer.velocity(in: self).x)
         


### PR DESCRIPTION
Hi Zattoo,

You can probably ignore vertical swipe during moving slider's knob. I had a problem when changing focus between slider and buttons below the slider (play, pause...), vertical swipe on the remote also triggers slider 'valueChanged' event. 

Btw. awesome pods, I'm thankful.

Regards,
Milos